### PR TITLE
:lock: Validate zip entry paths in broth/unzip

### DIFF
--- a/src/main/broth/unzip.ts
+++ b/src/main/broth/unzip.ts
@@ -7,7 +7,7 @@ const yauzlOpen = promisify(yauzl.open) as (
 ) => Promise<yauzl.ZipFile>;
 
 import * as sf from "main/os/sf";
-import { dirname, join } from "path";
+import { dirname, join, relative, resolve, sep } from "path";
 import { createWriteStream } from "fs";
 import { Logger } from "common/logger";
 import { ProgressInfo } from "common/types";
@@ -21,6 +21,40 @@ interface UnzipOpts {
 }
 
 const DIR_RE = /\/$/;
+
+/**
+ * Validates that the entry path does not escape the destination directory
+ * Prevents Zip Slip / Path Traversal attacks
+ */
+function validateEntryPath(destination: string, entryPath: string, entryFileName: string): void {
+  const resolvedDestination = resolve(destination);
+  const resolvedEntryPath = resolve(entryPath);
+
+  // Additional check: reject entries that start with absolute path markers
+  // This catches cases like "/etc/passwd" or "C:\Windows\..." before normalization
+  if (entryFileName.startsWith('/') || entryFileName.startsWith('\\')) {
+    throw new Error(
+      `Zip entry contains absolute path: "${entryFileName}"`
+    );
+  }
+
+  // Check for Windows drive letters (C:, D:, etc.)
+  if (/^[a-zA-Z]:/.test(entryFileName)) {
+    throw new Error(
+      `Zip entry contains absolute Windows path: "${entryFileName}"`
+    );
+  }
+
+  // Check if the resolved entry path is within the destination directory
+  const rel = relative(resolvedDestination, resolvedEntryPath);
+  const escapes =
+    rel === ".." || rel.startsWith(`..${sep}`) || rel === "";
+  if (escapes) {
+    throw new Error(
+      `Zip entry attempts path traversal: "${entryFileName}" resolves outside destination directory`
+    );
+  }
+}
 
 export async function unzip(opts: UnzipOpts) {
   const { archivePath, destination, logger } = opts;
@@ -43,6 +77,15 @@ export async function unzip(opts: UnzipOpts) {
     }
 
     const entryPath = join(destination, entry.fileName);
+
+    // Security fix: Validate entry path to prevent path traversal attacks
+    try {
+      validateEntryPath(destination, entryPath, entry.fileName);
+    } catch (e) {
+      logger.error(`Security: ${(e as Error).message}`);
+      throw e;
+    }
+
     logger.info(`Extracting ${entryPath}`);
 
     await sf.mkdir(dirname(entryPath));


### PR DESCRIPTION
## Summary

The ZIP extraction helper in `src/main/broth/unzip.ts` joined `entry.fileName` (taken verbatim from the archive) with the destination directory, without validating that the resolved path stays inside it. A crafted archive containing entries such as `../../../evil.txt`, `safe/../../../evil`, `C:\Windows\evil.dll` or `/etc/passwd` would be extracted outside the intended directory (Zip Slip, CWE-22).

This PR adds a `validateEntryPath()` guard that rejects an entry before any filesystem write when:

1. the entry name is an absolute path (leading `/` or `\`), or
2. it starts with a Windows drive letter (`C:`, `D:`, ...), or
3. the resolved entry path does not resolve inside the resolved destination directory (covers `..` segments and mixed `/` + `\` traversal on Windows).

The containment check compares `relative(destination, entryPath)` against `..` / `..${sep}` exactly, so legitimate dotted file names such as `..hidden.txt` are unaffected.

## Context / severity

To set expectations: `unzip` is only used by `src/main/broth/package.ts` to extract itch's own component archives (`butler`, `itch-setup`) downloaded over HTTPS from itch-controlled URLs, so this is defense-in-depth against a compromised feed or MITM rather than an attack reachable from game uploads (game installs are handled by butler itself). I still think it is worth fixing — archives are untrusted input and the whole app runs unsandboxed on user machines.

## How I verified

- `npm run ts-check` (`tsc -b`) passes.
- Behavior tests for the guard logic: 9/9 pass — normal file, nested dir, `..hidden.txt` (must stay allowed), `../evil.txt`, `safe/../../../etc/passwd`, `/etc/passwd`, `C:\Windows\evil.dll`, `\Windows\evil`, `..\..\evil` (all must be rejected).
- End-to-end PoC: built a ZIP with traversal entries and confirmed pre-patch extraction writes outside the destination, post-patch extraction throws `Zip entry attempts path traversal: ...` and nothing is written.

Happy to provide the PoC generator and test script if useful. No public issues/PRs/advisories mention this as far as I could find (searched `zip slip`, `path traversal`, `unzip` in issues and PRs).
